### PR TITLE
chore: add git attribute to ignore .js swagger files on the repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+client/docs/swagger-ui/* linguist-vendored


### PR DESCRIPTION
### Fix wrong language of the repo by add `.gitattributes`
- Current language on the repo 
   
<img width="317" alt="image" src="https://github.com/user-attachments/assets/6d760358-07df-4a06-8fad-20fc2aad0ecf">

- Ref https://github.com/cosmos/cosmos-sdk/blob/v0.50.8/.gitattributes
<img width="335" alt="image" src="https://github.com/user-attachments/assets/85a0306e-7a41-46e9-815e-d9f19ec43ac1">
